### PR TITLE
transfer: fix already spent warning

### DIFF
--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -5,6 +5,10 @@ function testWasAddressUsed (iota, address, cb) {
   iota.api.findTransactionObjects({ addresses: [ address ] }, (err, data) => {
     if (err) return cb(err)
 
-    cb(null, data.length > 1)
+    const foundSpent = data.filter((transaction) => {
+      return transaction.value < 0
+    })
+
+    cb(null, foundSpent.length > 0)
   })
 }


### PR DESCRIPTION
ignore incoming transactions, just warn if address was used to
send iota