### PR TITLE
errors: print friendly error for light nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Use `depth` to configure tip selection and `mwm` to change the minimum
 weight magnitude.
 
 
-### transfer &lt;amount> &lt;address&gt; [--json | --depth | --mwm | --force | --provider]
+### transfer &lt;amount&gt; &lt;address&gt; [--json | --depth | --mwm | --force | --provider]
 
 Transfers a given amount of *i* to an address.
 With `--force` enabled smidgen will not check if the target address was used

--- a/lib/handle-error.js
+++ b/lib/handle-error.js
@@ -8,6 +8,15 @@ function handleError (err) {
     process.exit(1)
   }
 
+  if (/COMMAND attachToTangle/.test(err.message)) {
+    err = new Error([
+      'Could not attach to Tangle.',
+      'To attach to the Tangle you need to connect to a full node.',
+      'Use --provider to switch node.'
+    ].join('\n'))
+    err.type = 'EUSAGE'
+  }
+
   if (err.type === 'EUSAGE') {
     if (Array.isArray(err.message.split('\n'))) {
       err.message.split('\n').forEach(el => log.error(el))


### PR DESCRIPTION

print a nice error in case the current node is not supporting
POW

Before
![screen shot 2017-09-06 at 19 43 43](https://user-images.githubusercontent.com/298166/30126569-97a172d2-933c-11e7-9287-9487063fd0c8.png)
After


![screen shot 2017-09-06 at 19 48 38](https://user-images.githubusercontent.com/298166/30126551-8d6b6066-933c-11e7-914b-78ae251448a4.png)

