### PR TITLE
fix #27: crash on error / invalid iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,16 +99,20 @@ Replays a specific transaction.
 
 Regenerates addresses to recover balances after a fresh snapshot. Default amount for addresses to generate is 25.
 
-### multisig create &lt;id&gt; &lt;file&gt; [--force]
+### multisig create &lt;id&gt; &lt;file&gt; [--no-validation | --force]
 
 Starts the creation of a multisignature wallet. `id` is the identifier for
 the first party that signs the wallet.
 
 `--force` can be used to overwrite an existing setup-file.
 
-### multisig add &lt;id&gt; &lt;file&gt;
+With `--no-validation` smidgen does not check if the provided seed may have been already used via getKeyIndex. This comes handy if you have no internet connection.
+
+### multisig add &lt;id&gt; &lt;file&gt; [--no-validation]
 
 Adds another party to the setup file used for multisignature wallet generation.
+
+With `--no-validation` smidgen does not check if the provided seed may have been already used via getKeyIndex. This comes handy if you have no internet connection.
 
 ### multisig finalize &lt;file&gt;
 
@@ -134,6 +138,8 @@ Multisignature wallets add an extra layer of security. With them, we can create 
 Smidgen uses a file that is shared between Seed-owners. With the file we manage the wallet with its addresses and transfers. This makes it easier to keep track of the current state. Private keys are not part of the file. Please make sure you read and understood the [Offical IOTA Multisig FAQ](https://github.com/iotaledger/wiki/blob/master/multisigs.md).
 
 **Important:** Right now smidgen is not doing the POW itself and depends on a full node as a provider for transfers. You can specify a full node with `--provider`.
+
+smidgen tries to make multisignature wallet creation safe. As part of it tries to find out if a seed was previously used with a single-signature wallet. This is done via `getKeyIndex`so it checks if the seed was used with another transaction before. However, when a node is offline, you have no WiFi or you don't want the additional safety net you can disable the checks with `--no-validation`.
 
 ### Creating a Multisignature Wallet
 

--- a/bin/smidgen.js
+++ b/bin/smidgen.js
@@ -19,7 +19,8 @@ const parsed = nopt({
   'threshold': [ Number ],
   'security': [ Number ],
   'balance': [ Number ],
-  'amount': [ Number ]
+  'amount': [ Number ],
+  'validation': [ Boolean ]
 
 }, {}, process.argv, 2)
 

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -1,7 +1,9 @@
 'use strict'
 
-exports.getKeyIndex = getKeyIndex
-function getKeyIndex (iota, opts = { security: 2 }, seed, cb) {
+exports.maybeGetKeyIndex = maybeGetKeyIndex
+function maybeGetKeyIndex (iota, opts = { security: 2, validation: true }, seed, cb) {
+  if (opts.validation === false) return cb(null, 0)
+
   iota.api.getAccountData(seed, opts, (err, res) => {
     if (err) return cb(err)
 

--- a/lib/cmds/multisig.js
+++ b/lib/cmds/multisig.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 
 const smidgen = require('../smidgen.js')
 const getSeed = require('../get-seed.js')
-const { getKeyIndex } = require('../accounts.js')
+const { maybeGetKeyIndex } = require('../accounts.js')
 
 const cmds = {
   'create': createWallet,
@@ -517,8 +517,18 @@ function addSigner (iota, opts = { security: 2, force: false }, seed, id, filena
   readAndCheckFile(filename, id, opts, (err, content) => {
     if (err) return cb(err)
 
-    getKeyIndex(iota, { security: opts.security }, seed, (err, keyIndex) => {
+    const kOpts = { security: opts.security, validation: opts.validation }
+    maybeGetKeyIndex(iota, kOpts, seed, (err, keyIndex) => {
       if (err) return cb(err)
+
+      if (keyIndex !== 0 && !opts.force) {
+        const keyErr = new Error([
+          'Seed seems to be used in a single-sig wallet already!',
+          'Use --force if you want to continue and know the risks involved.'
+        ])
+        keyErr.type = 'EUSAGE'
+        return cb(keyErr)
+      }
 
       const entry = createDigestEntry(iota, id, seed, keyIndex, opts.security)
       appendAndWrite(filename, entry)
@@ -563,8 +573,18 @@ function createWallet (iota, opts = { force: false, security: 2 }, seed, id, fil
   if (!id) return cb(new Error('id not set'))
   if (!seed) return cb(new Error('no seed set'))
 
-  getKeyIndex(iota, { security: opts.security }, seed, (err, keyIndex) => {
+  const kOpts = { security: opts.security, validation: opts.validation }
+  maybeGetKeyIndex(iota, kOpts, seed, (err, keyIndex) => {
     if (err) return cb(err)
+
+    if (keyIndex !== 0 && !opts.force) {
+      const keyErr = new Error([
+        'Seed seems to be used in a single-sig wallet already!',
+        'Use --force if you want to continue and know the risks involved.'
+      ])
+      keyErr.type = 'EUSAGE'
+      return cb(keyErr)
+    }
 
     const entry = createDigestEntry(iota, id, seed, keyIndex, opts.security)
     const content = {

--- a/lib/cmds/multisig.js
+++ b/lib/cmds/multisig.js
@@ -458,8 +458,10 @@ function cliAdd (id, filename, cb) {
   }
 
   function finalizeAdd (seed) {
-    addSigner(smidgen.iota, smidgen.config, seed, id, filename, (err, [ entry, content ]) => {
+    addSigner(smidgen.iota, smidgen.config, seed, id, filename, (err, res) => {
       if (err) return cb(err)
+
+      const [ entry ] = res
 
       const keyIndex = entry.indexMain
       const keyIndexRem = entry.indexRemainder
@@ -632,8 +634,10 @@ function cliCreate (id, filename, cb) {
   }
 
   function finalize (seed) {
-    createWallet(smidgen.iota, smidgen.config, seed, id, filename, (err, [ entry, res ]) => {
+    createWallet(smidgen.iota, smidgen.config, seed, id, filename, (err, data) => {
       if (err) return cb(err)
+
+      const [ entry, res ] = data
 
       if (filename) {
         const keyIndex = entry.indexMain

--- a/lib/handle-error.js
+++ b/lib/handle-error.js
@@ -17,6 +17,16 @@ function handleError (err) {
     err.type = 'EUSAGE'
   }
 
+  if (/Invalid Response/.test(err.message)) {
+    err = new Error([
+      'Received invalid response from node.',
+      'Retry command or try to use another node.',
+      '',
+      'Use --provider to switch node.'
+    ].join('\n'))
+    err.type = 'EUSAGE'
+  }
+
   if (/Not enough balance/.test(err.message)) {
     err = new Error([
       'It seems the address has not enough balance. This is not an error in smidgen.',

--- a/lib/smidgen.js
+++ b/lib/smidgen.js
@@ -51,7 +51,8 @@ function load (opts, cb) {
       threshold: 100,
       depth: 4,
       mwm: 14,
-      provider: 'http://iota.bitfinex.com:80'
+      provider: 'http://iota.bitfinex.com:80',
+      validation: true
     }
 
     smidgen.config = Object.assign({}, defaults, opts)
@@ -60,6 +61,10 @@ function load (opts, cb) {
     smidgen.iota = new IOTA({
       'provider': smidgen.config.provider
     })
+
+    if (!smidgen.config.validation) {
+      smidgen.log.info('', 'Online-Validations turned off. Take care!')
+    }
 
     cb(null, smidgen)
   })


### PR DESCRIPTION
in cases we had an error (and the result was undefined), smidgen
crashed as we tried to apply destructuring on the result (which
was undefined)

this also adds a `--no-validation` flag for offline usage.