### PR TITLE
config: add file based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Status: *smidgen is in late BETA right now*
 
   - [Installation](#installation)
+  - [Config](#config)
   - [Multisignature Wallets](#multisignature-wallets)
   - [Commands](#commands)
     - generate-seed
@@ -26,6 +27,10 @@ Status: *smidgen is in late BETA right now*
 ```
 npm install -g smidgen
 ```
+
+## Config
+
+smidgen will put a config file named `.smidgenrc` into your home. This way you can set arguments like `provider` on a permanent basis. Use commandline arguments to overwrite them temporaily.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Use `depth` to configure tip selection and `mwm` to change the minimum
 weight magnitude.
 
 
-### transfer &lt;amount&gt; &lt;address&gt; [--json | --depth | --mwm | --force | --provider]
+### transfer &lt;amount&gt; &lt;address&gt; [&lt;amount&gt; &lt;address&gt;...] [--json | --depth | --mwm | --force | --provider]
 
-Transfers a given amount of *i* to an address.
+Transfers a given amount of *i* to an address. You can define multiple output adresses.
 With `--force` enabled smidgen will not check if the target address was used
 before, which can lead to loss of IOTA for the owner of the address.
 
@@ -120,9 +120,9 @@ Creates two addresses for transferring IOTA from the multisig wallet.
 One as the main address, and a second one which is used for remaining balance
 after the transfer.
 
-### multisig transfer &lt;value&gt; &lt;address&gt; &lt;id&gt; &lt;file&gt; [--provider | --balance]
+### multisig transfer &lt;amount&gt; &lt;address&gt; [&lt;amount&gt; &lt;address&gt;...] &lt;id&gt; &lt;file&gt; [--provider | --balance]
 
-Transfers a given amout to the target address. Takes the id of the signing
+Transfers a given amout to one or more target addresses. Takes the id of the signing
 party and the multisignature file, containing the account data.
 
 With `--balance` we can override the current balance. This way smidgen will not query the tangle for the current balance.
@@ -387,11 +387,3 @@ smidgen.load(conf, (err, smidgen) => {
   })
 })
 ```
-
-### smidgen['transfer'](iotaLib, conf, address, amount, seed, cb)
-
-  - `conf` &lt;Object&gt;
-    - `json` &lt;Boolean&gt; return json
-    - `depth` &lt;Number&gt; set depth for tip selection
-    - `mwm` &lt;Number&gt; set minimum weight magnitude
-    - `force` &lt;Boolean&gt; continue even with already used addresses

--- a/bin/smidgen.js
+++ b/bin/smidgen.js
@@ -3,6 +3,9 @@
 'use strict'
 
 const nopt = require('nopt')
+const osenv = require('osenv')
+const path = require('path')
+const fs = require('fs')
 
 const smidgen = require('../lib/smidgen.js')
 const handleError = require('../lib/handle-error.js')
@@ -23,6 +26,13 @@ const parsed = nopt({
   'validation': [ Boolean ]
 
 }, {}, process.argv, 2)
+
+const home = osenv.home()
+parsed.smidgenconf = path.join(home, '.smidgenrc')
+
+if (!fs.existsSync(parsed.smidgenconf)) {
+  fs.writeFileSync(parsed.smidgenconf, '{"provider": "http://iota.bitfinex.com:80"}')
+}
 
 const cmd = parsed.argv.remain.shift()
 

--- a/lib/cmds/help.js
+++ b/lib/cmds/help.js
@@ -42,5 +42,5 @@ ${cmds}
 Get detailed help with:
 smidgen help <command>
 
-smidgen@${pkg.version} - iota.lib.js@${versionIotaLib}`
+smidgen@${pkg.version} - iota.lib.js@${versionIotaLib} - conf: ${smidgen.smidgenconf}`
 }

--- a/lib/cmds/help.js
+++ b/lib/cmds/help.js
@@ -2,6 +2,7 @@
 
 const smidgen = require('../smidgen.js')
 const pkg = require('../../package.json')
+const versionIotaLib = pkg.dependencies['iota.lib.js']
 
 exports.cli = cliHelp
 exports.cli.usage = 'Usage: smidgen help'
@@ -41,5 +42,5 @@ ${cmds}
 Get detailed help with:
 smidgen help <command>
 
-smidgen@${pkg.version}`
+smidgen@${pkg.version} - iota.lib.js@${versionIotaLib}`
 }

--- a/lib/cmds/multisig.js
+++ b/lib/cmds/multisig.js
@@ -1,10 +1,16 @@
 'use strict'
 
 const fs = require('fs')
+const assert = require('assert')
 
 const smidgen = require('../smidgen.js')
 const getSeed = require('../get-seed.js')
 const { maybeGetKeyIndex } = require('../accounts.js')
+const {
+  parseOutputs,
+  validateInputs,
+  getFullTransferObjects
+} = require('./transfer.js')
 
 const cmds = {
   'create': createWallet,
@@ -20,7 +26,7 @@ smidgen multisig create <id> <file>
 smidgen multisig add <id> <file>
 smidgen multisig finalize <id> <file>
 
-smidgen multisig transfer <value> <address> <id> <file>
+smidgen multisig transfer [<value> <address> ...] <id> <file> [--provider | --balance]
 
 Example:
 smidgen multisig create rocko wallet-setup.txt`
@@ -29,14 +35,14 @@ const shortUsage = `
 multisig create <id> <file> [--force]
 multisig add <id> <file>
 multisig finalize <id> <file>
-multisig transfer <value> <address> <id> <file> [--provider | --balance]
+multisig transfer <value> <address> [<value> <address> ...] <id> <file> [--provider | --balance]
 `
 
 exports.cli = cli
 exports.cli.usage = shortUsage
 
 function cli ([ command, ...args ], cb) {
-  let id, filename, amount, address
+  let id, filename
   switch (command) {
     case 'create':
       [ id, filename ] = args
@@ -54,8 +60,11 @@ function cli ([ command, ...args ], cb) {
       break
 
     case 'transfer':
-      [ amount, address, id, filename ] = args
-      cliTransfer(amount, address, id, filename, cb)
+      filename = args.pop()
+      id = args.pop()
+
+      const parsedOutputs = parseOutputs(args)
+      cliTransfer(parsedOutputs, id, filename, cb)
       break
 
     default:
@@ -66,22 +75,22 @@ function cli ([ command, ...args ], cb) {
   }
 }
 
-function cliTransfer (value, address, id, filename, cb) {
-  if (!value || !address || !id || !filename) {
-    const err = new Error(
-      'Usage: smidgen multisig transfer <value> <address> <id> <file>'
-    )
-    err.type = 'EUSAGE'
-    return cb(err)
-  }
+function cliTransfer (transfers, id, filename, cb) {
+  const errors = transfers.reduce((acc, el) => {
+    const { address, value } = el
 
-  value = +value
-  if (typeof value !== 'number') {
+    const err = validateInputs(smidgen.iota, address, value)
+
+    if (err) acc.push(err)
+
+    return acc
+  }, [])
+
+  if (errors.length) {
     const err = new Error([
-      'Value must be a number',
-      'Usage: smidgen multisig transfer <value> <address> <id> <file>'
+      errors[0],
+      `smidgen multisig transfer [<value> <address> ...] <id> <file>`
     ].join('\n'))
-
     err.type = 'EUSAGE'
     return cb(err)
   }
@@ -99,7 +108,7 @@ function cliTransfer (value, address, id, filename, cb) {
     readAndCheckFile(filename, null, smidgen.config, (err, data) => {
       if (err) return cb(err)
 
-      transfer(smidgen.iota, smidgen.config, value, address, id, filename, data, cb)
+      transfer(smidgen.iota, smidgen.config, transfers, id, filename, data, cb)
     })
   })
 }
@@ -125,7 +134,12 @@ function getSecuritySum (data) {
   return res
 }
 
-function transfer (iota, opts, value, targetAddress, id, filename, data, cb) {
+function transfer (iota, opts, transfers, id, filename, data, cb) {
+  assert.ok(
+    Array.isArray(transfers),
+    'transfers must be an array'
+  )
+
   const current = data.current
 
   if (!current) {
@@ -139,6 +153,8 @@ function transfer (iota, opts, value, targetAddress, id, filename, data, cb) {
   if (!current.transfer) {
     current.transfer = {}
   }
+
+  const multisigTransfer = getFullTransferObjects(iota, transfers, { removeChecksum: true })
 
   const signingOrder = getSigningOrder(current)
   const securitySum = getSecuritySum(current)
@@ -185,13 +201,6 @@ function transfer (iota, opts, value, targetAddress, id, filename, data, cb) {
   function continueWithSeed (seed) {
     const address = iota.utils.noChecksum(current.mainAddress)
 
-    const multisigTransfer = [{
-      address: iota.utils.noChecksum(targetAddress),
-      value: value,
-      message: '',
-      tag: '9'.repeat(27)
-    }]
-
     const input = {
       'address': iota.utils.noChecksum(current.mainAddress),
       'securitySum': securitySum,
@@ -228,7 +237,7 @@ function transfer (iota, opts, value, targetAddress, id, filename, data, cb) {
           current.transfer.bundles.initial = initiatedBundle
           current.transfer.bundles.signed = []
 
-          current.transfer.meta = multisigTransfer[0]
+          current.transfer.meta = multisigTransfer
 
           iota.multisig.addSignature(
             initiatedBundle,

--- a/lib/cmds/transfer.js
+++ b/lib/cmds/transfer.js
@@ -88,12 +88,16 @@ function checkTransfers (iota, fullTransfers, cb) {
 }
 
 exports.getFullTransferObjects = getFullTransferObjects
-function getFullTransferObjects (iota, transfers) {
+function getFullTransferObjects (iota, transfers, opts = { removeChecksum: false }) {
   const meta = { message: '', tag: '' }
 
   const fullTransfers = transfers.map((t) => {
-    if (t.address.length === 81) {
+    if (!opts.removeChecksum && t.address.length === 81) {
       t.address = iota.utils.addChecksum(t.address)
+    }
+
+    if (opts.removeChecksum) {
+      t.address = iota.utils.noChecksum(t.address)
     }
 
     return Object.assign({}, meta, t)
@@ -158,6 +162,7 @@ function cli (outputs, cb) {
   })
 }
 
+exports.validateInputs = validateInputs
 function validateInputs (iota, address, amount) {
   if (!address || !amount) {
     return new Error('Address and amount must be defined')

--- a/lib/cmds/transfer.js
+++ b/lib/cmds/transfer.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const async = require('async')
 
 const smidgen = require('../smidgen.js')
 const getSeed = require('../get-seed.js')
@@ -12,67 +13,51 @@ module.exports = (exports = transfer)
 function transfer (
   iota,
   opts = { json: false, depth: 4, mwm: 14, force: false },
-  address,
-  amount,
+  transfers,
   seed,
   cb
 ) {
-  assert.equal(
-    typeof address,
-    'string',
-    'address must be a string'
+  assert.ok(
+    Array.isArray(transfers),
+    'transfers must be an array'
   )
 
-  assert.equal(
-    typeof amount,
-    'number',
-    'value must be a number'
-  )
-
-  assert.equal(
-    typeof seed,
-    'string',
-    'value must be a string'
-  )
-
-  if (address.length === 81) {
-    address = iota.utils.addChecksum(address)
-  }
-
-  const transfers = [{
-    address: address,
-    value: amount,
-    message: '',
-    tag: ''
-  }]
+  const fullTransfers = getFullTransferObjects(iota, transfers)
+  const overallOutput = getOverallOutput(fullTransfers)
 
   getBalanceForSeed(iota, { json: false }, seed, (err, balance) => {
     if (err) return cb(err)
 
-    if (amount > balance) {
+    if (overallOutput > balance) {
       const err = new Error(`Not enough IOTA available. Available: ${balance}i`)
       err.type = 'EUSAGE'
       return cb(err)
     }
 
-    testWasAddressUsed(iota, address, (err, used) => {
+    if (opts.force) return transfer()
+
+    checkTransfers(iota, fullTransfers, (err, res) => {
       if (err) return cb(err)
 
-      if (used && !opts.force) {
-        const err = new Error([
-          'Address was already used. Use --force if you really want to continue.',
-          'Warning: This can lead to a loss of IOTA!'
-        ].join('\n'))
-        err.type = 'EUSAGE'
-        return cb(err)
-      }
+      if (!res.length) return transfer()
 
-      transfer()
+      const msg = res.map((el) => {
+        return `Was used: ${el.address}`
+      })
+
+      msg.unshift('Seems the following addresses were used already:')
+      msg.push('Use --force if you really want to continue.')
+      msg.push('Warning: This can lead to a loss of IOTA!')
+
+      const usageErr = new Error(msg.join('\n'))
+      usageErr.type = 'EUSAGE'
+
+      return cb(usageErr)
     })
   })
 
   function transfer () {
-    iota.api.sendTransfer(seed, opts.depth, opts.mwm, transfers, (err, data) => {
+    iota.api.sendTransfer(seed, opts.depth, opts.mwm, fullTransfers, (err, data) => {
       if (err) return cb(err)
 
       cb(null, data)
@@ -80,18 +65,74 @@ function transfer (
   }
 }
 
-const usage = 'Usage: smidgen transfer <value> <address> \n' +
+function checkTransfers (iota, fullTransfers, cb) {
+  const task = (transfer, cb) => {
+    testWasAddressUsed(iota, transfer.address, (err, used) => {
+      if (err) return cb(err)
+
+      const res = { address: transfer.address, used: used }
+      return cb(null, res)
+    })
+  }
+
+  const limit = 5
+  async.mapLimit(fullTransfers, limit, task, (err, res) => {
+    if (err) return cb(err)
+
+    const usedAddresses = res.filter((el) => {
+      return el.used
+    })
+
+    cb(null, usedAddresses)
+  })
+}
+
+exports.getFullTransferObjects = getFullTransferObjects
+function getFullTransferObjects (iota, transfers) {
+  const meta = { message: '', tag: '' }
+
+  const fullTransfers = transfers.map((t) => {
+    if (t.address.length === 81) {
+      t.address = iota.utils.addChecksum(t.address)
+    }
+
+    return Object.assign({}, meta, t)
+  })
+
+  return fullTransfers
+}
+
+exports.getOverallOutput = getOverallOutput
+function getOverallOutput (transfers) {
+  const overallOutput = transfers.reduce((acc, el) => {
+    acc = acc + el.value
+    return acc
+  }, 0)
+
+  return overallOutput
+}
+
+const usage = 'Usage: smidgen transfer <value> <address> [value address ...]\n' +
   ' [--json | --depth | --mwm | --force | --provider]'
 exports.cli = cli
 exports.cli.usage = usage
 
-function cli ([ amount, address ], cb) {
-  amount = +amount
+function cli (outputs, cb) {
+  const parsedOutputs = parseOutputs(outputs)
 
-  const reason = validateInputs(smidgen.iota, address, amount)
-  if (reason) {
+  const errors = parsedOutputs.reduce((acc, el) => {
+    const { address, value } = el
+
+    const err = validateInputs(smidgen.iota, address, value)
+
+    if (err) acc.push(err)
+
+    return acc
+  }, [])
+
+  if (errors.length) {
     const err = new Error([
-      reason,
+      errors[0],
       usage
     ].join('\n'))
     err.type = 'EUSAGE'
@@ -100,7 +141,8 @@ function cli ([ amount, address ], cb) {
 
   getSeed((err, seed) => {
     if (err) return cb(err)
-    transfer(smidgen.iota, smidgen.config, address, amount, seed, (err, transaction) => {
+
+    transfer(smidgen.iota, smidgen.config, parsedOutputs, seed, (err, transaction) => {
       if (err) return cb(err)
 
       if (smidgen.config.json) {
@@ -108,7 +150,6 @@ function cli ([ amount, address ], cb) {
         return cb(null)
       }
 
-      smidgen.log.info('', `Successfully sent ${amount}i to ${address}`)
       const hash = transaction[0].hash
       smidgen.log.info('', `Transaction sent, hash: ${hash}`)
       smidgen.log.info('', `Reattach with \`smidgen reattach ${hash}\``)
@@ -119,25 +160,44 @@ function cli ([ amount, address ], cb) {
 
 function validateInputs (iota, address, amount) {
   if (!address || !amount) {
-    return 'Address and amount must be defined'
+    return new Error('Address and amount must be defined')
   }
 
   const val = parseInt(amount, 10)
   if (Number.isNaN(val)) {
-    return 'Amount must be an integer'
+    return new Error('Amount must be an integer, got:' + amount)
   }
 
   if (Math.floor(amount) !== amount) {
-    return 'Amount must be an integer'
+    return new Error('Amount must be an integer, got:' + amount)
   }
 
   if (!iota.valid.isAddress(address)) {
-    return `Address "${address}" is invalid`
+    return new Error(`Address "${address}" is invalid`)
   }
 
   if (address.length === 90 && !iota.utils.isValidChecksum(address)) {
-    return `Address "${address}" is invalid`
+    return new Error(`Address "${address}" is invalid`)
   }
 
   return null
+}
+
+exports.parseOutputs = parseOutputs
+function parseOutputs (outputs) {
+  const o = outputs.reduce((acc, el, i) => {
+    if ((i + 1) % 2 === 0) { // address
+      const tmp = acc.pop()
+      tmp.address = el
+      acc.push(tmp)
+      return acc
+    }
+
+    const item = { value: +el }
+
+    acc.push(item)
+    return acc
+  }, [])
+
+  return o
 }

--- a/lib/cmds/transfer.js
+++ b/lib/cmds/transfer.js
@@ -89,7 +89,7 @@ function checkTransfers (iota, fullTransfers, cb) {
 
 exports.getFullTransferObjects = getFullTransferObjects
 function getFullTransferObjects (iota, transfers, opts = { removeChecksum: false }) {
-  const meta = { message: '', tag: '' }
+  const meta = { message: '', tag: '9'.repeat(27) }
 
   const fullTransfers = transfers.map((t) => {
     if (!opts.removeChecksum && t.address.length === 81) {

--- a/lib/smidgen.js
+++ b/lib/smidgen.js
@@ -43,30 +43,42 @@ function load (opts, cb) {
     cliFuncs = c.cliFuncs
     commandFuncs = c.commandFuncs
 
-    // fake config until file based config is implemented
-    const defaults = {
-      balance: undefined,
-      security: 2,
-      amount: 25,
-      threshold: 100,
-      depth: 4,
-      mwm: 14,
-      provider: 'http://iota.bitfinex.com:80',
-      validation: true
-    }
+    fs.readFile(opts.smidgenconf, 'utf8', (err, txt) => {
+      if (err) return cb(err)
 
-    smidgen.config = Object.assign({}, defaults, opts)
-    smidgen.log = log
+      let fileConf
+      try {
+        fileConf = JSON.parse(txt)
+      } catch (e) {
+        return cb(e)
+      }
 
-    smidgen.iota = new IOTA({
-      'provider': smidgen.config.provider
+      const defaults = {
+        balance: undefined,
+        security: 2,
+        amount: 25,
+        threshold: 100,
+        depth: 4,
+        mwm: 14,
+        provider: 'http://iota.bitfinex.com:80',
+        validation: true
+      }
+
+      smidgen.config = Object.assign({}, defaults, fileConf, opts)
+      smidgen.log = log
+
+      smidgen.iota = new IOTA({
+        'provider': smidgen.config.provider
+      })
+
+      smidgen.smidgenconf = opts.smidgenconf
+
+      if (!smidgen.config.validation) {
+        smidgen.log.info('', 'Online-Validations turned off. Take care!')
+      }
+
+      cb(null, smidgen)
     })
-
-    if (!smidgen.config.validation) {
-      smidgen.log.info('', 'Online-Validations turned off. Take care!')
-    }
-
-    cb(null, smidgen)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "preferGlobal": true,
   "dependencies": {
     "async": "2.6.0",
-    "iota.lib.js": "0.4.3",
+    "iota.lib.js": "0.4.5",
     "mkdirp": "0.5.1",
     "nopt": "4.0.1",
     "npmlog": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mkdirp": "0.5.1",
     "nopt": "4.0.1",
     "npmlog": "4.1.2",
+    "osenv": "0.1.4",
     "read": "1.0.7",
     "single-line-log": "1.1.2"
   },

--- a/test/unit-transfer.js
+++ b/test/unit-transfer.js
@@ -36,8 +36,8 @@ describe('unit: transfer', () => {
     assert.deepEqual(
       res,
       [
-        { address: 'foo', value: 1, tag: '', message: '' },
-        { address: 'apple', value: 5, tag: '', message: '' }
+        { address: 'foo', value: 1, tag: '999999999999999999999999999', message: '' },
+        { address: 'apple', value: 5, tag: '999999999999999999999999999', message: '' }
       ]
     )
   })
@@ -52,8 +52,8 @@ describe('unit: transfer', () => {
     assert.deepEqual(
       res,
       [
-        { address: '999999999999999999999999999999999999999999999999999999999999999999999999999999999A9BEONKZW', value: 1, tag: '', message: '' },
-        { address: '999999999999999999999999999999999999999999999999999999999999999999999999999999999A9BEONKZW', value: 5, tag: '', message: '' }
+        { address: '999999999999999999999999999999999999999999999999999999999999999999999999999999999A9BEONKZW', value: 1, tag: '999999999999999999999999999', message: '' },
+        { address: '999999999999999999999999999999999999999999999999999999999999999999999999999999999A9BEONKZW', value: 5, tag: '999999999999999999999999999', message: '' }
       ]
 
     )

--- a/test/unit-transfer.js
+++ b/test/unit-transfer.js
@@ -1,0 +1,75 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const assert = require('assert')
+
+const transfer = require('../lib/cmds/transfer.js')
+const IOTA = require('iota.lib.js')
+const iota = new IOTA()
+
+describe('unit: transfer', () => {
+  it('parseOutputs parses outputs', () => {
+    const res = transfer.parseOutputs(
+      [1, 'foo', 2, 'bar', 3, 'baz', 4, 'apple']
+    )
+
+    assert.deepEqual(
+      res,
+      [ { value: 1, address: 'foo' },
+        { value: 2, address: 'bar' },
+        { value: 3, address: 'baz' },
+        { value: 4, address: 'apple' } ]
+    )
+  })
+
+  it('getFullTransferObjects adds metadata', () => {
+    const input = [
+      { address: 'foo', value: 1 },
+      { address: 'apple', value: 5 }
+    ]
+    const res = transfer.getFullTransferObjects(
+      iota,
+      input
+    )
+
+    assert.deepEqual(
+      res,
+      [
+        { address: 'foo', value: 1, tag: '', message: '' },
+        { address: 'apple', value: 5, tag: '', message: '' }
+      ]
+    )
+  })
+
+  it('getFullTransferObjects adds checksums', () => {
+    const input = [
+      { address: '999999999999999999999999999999999999999999999999999999999999999999999999999999999', value: 1 },
+      { address: '999999999999999999999999999999999999999999999999999999999999999999999999999999999', value: 5 }
+    ]
+    const res = transfer.getFullTransferObjects(iota, input)
+
+    assert.deepEqual(
+      res,
+      [
+        { address: '999999999999999999999999999999999999999999999999999999999999999999999999999999999A9BEONKZW', value: 1, tag: '', message: '' },
+        { address: '999999999999999999999999999999999999999999999999999999999999999999999999999999999A9BEONKZW', value: 5, tag: '', message: '' }
+      ]
+
+    )
+  })
+
+  it('getOverallOutput parses outputs', () => {
+    const res = transfer.parseOutputs(
+      [1, 'foo', 2, 'bar', 3, 'baz', 4, 'apple']
+    )
+
+    assert.deepEqual(
+      res,
+      [ { value: 1, address: 'foo' },
+        { value: 2, address: 'bar' },
+        { value: 3, address: 'baz' },
+        { value: 4, address: 'apple' } ]
+    )
+  })
+})


### PR DESCRIPTION
config is lazily created on startup. commandline arguments
overwrite the file based config, i.e. `--provider` via commandline
will overwrite the defautl provider and the provider in the config
file.

feature in f29a4d3

depends on #31 