### PR TITLE
Initial support for promote command

### DIFF
--- a/lib/cmds/promote.js
+++ b/lib/cmds/promote.js
@@ -10,7 +10,7 @@ function promote (
 ) {
   const spamTransfer = [{address: '9'.repeat(81), value: 0, message: '', tag: ''}]
   iota.api.promoteTransaction(transaction, opts.depth, opts.mwm, spamTransfer,
-          {interrupt: false, delay: 0}, cb);
+          {interrupt: false, delay: 0}, cb)
 }
 
 const usage = 'Usage: smidgen promote <tail transaction hash> [--provider]'
@@ -41,4 +41,3 @@ function cliPromote ([ transaction ], cb) {
     smidgen.log.info('', 'Transaction successfully promoted')
   })
 }
-

--- a/lib/cmds/promote.js
+++ b/lib/cmds/promote.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const smidgen = require('../smidgen.js')
+
+function promote (
+  iota,
+  opts = { depth: 4, mwm: 14 },
+  transaction,
+  cb
+) {
+  const spamTransfer = [{address: '9'.repeat(81), value: 0, message: '', tag: ''}]
+  iota.api.promoteTransaction(transaction, opts.depth, opts.mwm, spamTransfer,
+          {interrupt: false, delay: 0}, cb);
+}
+
+const usage = 'Usage: smidgen promote <tail transaction hash> [--provider]'
+exports.cli = cliPromote
+exports.cli.usage = usage
+function cliPromote ([ transaction ], cb) {
+  if (!transaction) {
+    const err = new Error([
+      'No transaction given. Please provide a transaction.',
+      usage
+    ].join('\n'))
+    err.type = 'EUSAGE'
+    return cb(err)
+  }
+
+  if (!smidgen.iota.valid.isHash(transaction)) {
+    const err = new Error([
+      'No valid transaction hash given.',
+      usage
+    ].join('\n'))
+    err.type = 'EUSAGE'
+    return cb(err)
+  }
+
+  promote(smidgen.iota, smidgen.config, transaction, (err, data) => {
+    if (err) return cb(err)
+
+    smidgen.log.info('', 'Transaction successfully promoted')
+  })
+}
+

--- a/lib/handle-error.js
+++ b/lib/handle-error.js
@@ -17,7 +17,7 @@ function handleError (err) {
     ].join('\n'))
     err.type = 'EUSAGE'
   }
-  
+
   if (/Request Error: reference transaction is too old/.test(err.message)) {
     err = new Error([
       'Could not promote transaction.',
@@ -25,7 +25,7 @@ function handleError (err) {
     ].join('\n'))
     err.type = 'EUSAGE'
   }
-  
+
   if (/Request Error: starting tip failed consistency check/.test(err.message)) {
     err = new Error([
       'Could not promote transaction.',

--- a/lib/handle-error.js
+++ b/lib/handle-error.js
@@ -17,6 +17,22 @@ function handleError (err) {
     ].join('\n'))
     err.type = 'EUSAGE'
   }
+  
+  if (/Request Error: reference transaction is too old/.test(err.message)) {
+    err = new Error([
+      'Could not promote transaction.',
+      'The transaction is too old to promote, try with reattach.'
+    ].join('\n'))
+    err.type = 'EUSAGE'
+  }
+  
+  if (/Request Error: starting tip failed consistency check/.test(err.message)) {
+    err = new Error([
+      'Could not promote transaction.',
+      'Starting tip failed consistency check.'
+    ].join('\n'))
+    err.type = 'EUSAGE'
+  }
 
   if (/Invalid Response/.test(err.message)) {
     err = new Error([


### PR DESCRIPTION
Hi, since I need the promote command, I implemented a very basic version of it on my adapted fork.

The error detection probably needs some adjustments and the promoting support from nodes is not always smooth, had more luck with http://field.carriota.com:80 as provider, but often it fails when checking the consistency.

Anyway, this is just to get basic promoting and a possible starting point, in case you are interested, if not, no worries, I'm happy to maintain my own fork.