### PR TITLE
transfer: return provider for promote and reattach

### DIFF
--- a/lib/cmds/transfer.js
+++ b/lib/cmds/transfer.js
@@ -156,8 +156,8 @@ function cli (outputs, cb) {
 
       const hash = transaction[0].hash
       smidgen.log.info('', `Transaction sent, hash: ${hash}`)
-      smidgen.log.info('', `Reattach with \`smidgen reattach ${hash}\``)
-      smidgen.log.info('', `Promote with \`smidgen promote ${hash}\``)
+      smidgen.log.info('', `Reattach with \`smidgen reattach ${hash} --provider=${smidgen.config.provider}\``)
+      smidgen.log.info('', `Promote with \`smidgen promote ${hash} --provider=${smidgen.config.provider}\``)
       return cb(null)
     })
   })


### PR DESCRIPTION
convienently return the used provider, so its faster and easier
to copy & paste reattach / promote instructions.